### PR TITLE
Improved project quality & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,46 @@
-# MultiLoader Template
+# Ancient Structures
 
-This project provides a Gradle project template that can compile mods for both Forge and Fabric using a common sourceset. This project does not require any third party libraries or dependencies. If you have any questions or want to discuss the project join our [Discord](https://discord.myceliummod.network).
+[curseforge]: https://img.shields.io/badge/CurseForge-Download-orange?style=flat-square&logo=curseforge&labelColor=0d1117
+[curseforgeLink]: https://www.curseforge.com/minecraft/mc-mods/ancient-cultural-structures
+[modrinth]: https://img.shields.io/badge/Modrinth-Download-1bd96a?style=flat-square&logo=modrinth&logoColor=white&labelColor=0d1117
+[modrinthLink]: https://modrinth.com/mod/ancient-structures
 
-## Getting Started
+[ ![curseforge][] ][curseforgeLink] [ ![modrinth][] ][modrinthLink] <a href="https://discord.gg/2ucZQznWKF"><img alt="Discord" src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white&labelColor=0d1117"></a>
 
-## IntelliJ IDEA
-This guide will show how to import the MultiLoader Template into IntelliJ IDEA. The setup process is roughly equivalent to setting up Forge and Fabric independently and should be very familiar to anyone who has worked with their MDKs.
+![Ancient Structures](https://i.imgur.com/qVTTL4k.png)
 
-1. Clone or download this repository to your computer.
-2. Configure the project by editing the `group`, `mod_name`, `mod_author`, and `mod_id` properties in the `gradle.properties` file. You will also need to change the `rootProject.name`  property in `settings.gradle`, this should match the folder name of your project, or else IDEA may complain.
-3. Open the template's root folder as a new project in IDEA. This is the folder that contains this README file and the gradlew executable.
-4. If your default JVM/JDK is not Java 17 you will encounter an error when opening the project. This error is fixed by going to `File > Settings > Build, Execution, Deployment > Build Tools > Gradle > Gradle JVM`and changing the value to a valid Java 17 JVM. You will also need to set the Project SDK to Java 17. This can be done by going to `File > Project Structure > Project SDK`. Once both have been set open the Gradle tab in IDEA and click the refresh button to reload the project.
-5. Open the Gradle tab in IDEA if it has not already been opened. Navigate to `Your Project > Common > Tasks > vanilla gradle > decompile`. Run this task to decompile Minecraft.
-6. Open your Run/Debug Configurations. Under the Application category there should now be options to run Forge and Fabric projects. Select one of the client options and try to run it.
-7. Assuming you were able to run the game in step 7 your workspace should now be set up.
+A Minecraft mod that generates ancient structures from various world cultures directly in the overworld.
 
-### Eclipse
-While it is possible to use this template in Eclipse it is not recommended. During the development of this template multiple critical bugs and quirks related to Eclipse were found at nearly every level of the required build tools. While we continue to work with these tools to report and resolve issues support for projects like these are not there yet. For now Eclipse is considered unsupported by this project. The development cycle for build tools is notoriously slow so there are no ETAs available.
+Available for **Fabric** and **Forge** on Minecraft **1.20.1**.
 
-## Development Guide
-When using this template the majority of your mod is developed in the Common project. The Common project is compiled against the vanilla game and is used to hold code that is shared between the different loader-specific versions of your mod. The Common project has no knowledge or access to ModLoader specific code, apis, or concepts. Code that requires something from a specific loader must be done through the project that is specific to that loader, such as the Forge or Fabric project.
+---
 
-Loader specific projects such as the Forge and Fabric project are used to load the Common project into the game. These projects also define code that is specific to that loader. Loader specific projects can access all of the code in the Common project. It is important to remember that the Common project can not access code from loader specific projects.
+## About
+
+Ancient Structures brings forgotten civilizations back to life in your Minecraft world. Explore a wide variety of hand-crafted structures scattered across different biomes, each rooted in a distinct culture — from Germanic villages to Roman monuments, Japanese architecture, and Mayan temples.
+
+Every civilization comes with its own guardians to face, unique loot to collect, and a set of advancements to unlock, offering a rich and varied exploration experience throughout your world.
+
+---
+
+## Dawn of Time Ecosystem
+
+This mod is part of the **Dawn of Time** modding ecosystem and requires [Dawn of Time Builder](https://www.curseforge.com/minecraft/mc-mods/dawn-of-time-builder) and [Armor of the Ages](https://www.curseforge.com/minecraft/mc-mods/armor-of-the-ages) to run.
+
+It is also the flagship entry of the **Ancient Structures** series. Check out the other mods in the series:
+
+- [Ancient Structures: Edo Japan](https://www.curseforge.com/minecraft/mc-mods/ancient-structures-edo-japan)
+- [Ancient Structures: Chinese](https://www.curseforge.com/minecraft/mc-mods/ancient-structures-chinese)
+
+---
+
+## Authors
+
+- **TheGoldenWorld** — structures, ideas & project owner
+- **Jackie** — structure helper
+- **Lekter** — windmill structure
+- **Poulpinou** — code help & project creation
+
+## License
+
+GNU GPL 3.0 — see [LICENSE](LICENSE)

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -29,13 +29,13 @@ side = "BOTH"
 [[dependencies.${mod_id}]]
 modId = "dawnoftimebuilder"
 mandatory = true
-versionRange = "[1.5.13,)"
+versionRange = "[1.5.33,)"
 ordering = "AFTER"
 side = "BOTH"
 
 [[dependencies.${mod_id}]]
 modId = "armoroftheages"
 mandatory = true
-versionRange = "[1.3.5,)"
+versionRange = "[1.3.8,)"
 ordering = "AFTER"
 side = "BOTH"


### PR DESCRIPTION
## Summary

- Rewrote README from scratch — replaced the MultiLoader template placeholder with a proper mod description, CurseForge/Modrinth/Discord badges, project image, Dawn of Time ecosystem section, Ancient Structures series links, and author credits
- Removed empty unused `military.json` loot table (0 bytes, unreferenced)
- Aligned Forge dependency minimum versions with Fabric (`dawnoftimebuilder` 1.5.13 → 1.5.33, `armoroftheages` 1.3.5 → 1.3.8)

## Test plan

- [ ] Verify README renders correctly on GitHub (badges, image, links)
- [ ] Confirm `military.json` removal causes no in-game errors
- [ ] Test Forge loader still accepts the updated version constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)