### PR TITLE
Fix: autopublish forge JAR crash + Quilt + display name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ configure([project(":fabric"), project(":forge")]) {
     publishMods {
         changelog = patchNoteProvider
         type = STABLE
+        displayName = "Ancient Structures - ${project.property("minecraft_version")} v${project.version}"
 
         curseforge {
             projectId = "1300212"

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -65,5 +65,5 @@ loom {
 
 publishMods {
     file = remapJar.archiveFile
-    modLoaders.addAll("fabric", "quilt")
+    modLoaders.add("fabric")
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -56,6 +56,11 @@ dependencies {
     modRuntimeOnly("maven.modrinth:dawn-of-time:1.5.44-forge")
 }
 
+tasks.named('jar', Jar) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    finalizedBy('reobfJar')
+}
+
 publishMods {
     file = jar.archiveFile
     modLoaders.add("forge")

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ fabric_version=0.92.1+1.20.1
 fabric_loader_version=0.16.9
 
 # Forge
-forge_version=47.2.20
+forge_version=47.4.16
 forge_loader_version_range=[47,)
 
 # Gradle


### PR DESCRIPTION
## Root Cause

`publishMods` depended only on the `jar` task, which produces a JAR with **Mojang-mapped** method references (Parchment dev mappings). The `reobfJar` task — which converts these to **SRG names** for production — was never in the dependency chain.

At runtime, Forge's class loader expects SRG names and maps them to the current Mojang names. Without reobfuscation, the JAR contains raw Mojang names. When `CriteriaTriggers.register()` signature changed between Forge 47.2.x and 47.4.x, the raw Mojang call found the wrong descriptor → `NoSuchMethodError`.

This explains why:
- ✅ IntelliJ build works → `gradlew build` runs `reobfJar` automatically
- ✅ Fabric works → uses `remapJar.archiveFile` (Loom's equivalent of reobfJar)
- ❌ Autopublish Forge crashed → `publishMods` only ran `jar`, skipped `reobfJar`

## Changes

**`forge/build.gradle`**
- Add `finalizedBy('reobfJar')` to `jar` task — ensures the JAR is always reobfuscated before any downstream use, including publish
- Add `duplicatesStrategy = DuplicatesStrategy.EXCLUDE` — fixes duplicate mixin JSON from common sourceSet inclusion

**`fabric/build.gradle`**
- Remove `"quilt"` from `modLoaders` — mod is not Quilt-compatible

**`build.gradle`**
- Add `displayName = "Ancient Structures - {minecraft_version} v{version}"` — published files now named correctly

**`gradle.properties`**
- Bump `forge_version` from `47.2.20` to `47.4.16` — compile against latest Forge API

🤖 Generated with [Claude Code](https://claude.com/claude-code)